### PR TITLE
Fix incorrect laravel extra key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Niladam\\LaravelZabbix\\ZabbixServiceProvider"
+                "Niladam\\LaravelZabbix\\LaravelZabbixServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
The composer json contained an invalid filename for the service provider..